### PR TITLE
chore: write simple installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,13 @@ Zig references I used:
 
 # Installation
 
-I promise that I will write an installation tutorial... maybe (feel free to help with that with a PR).
+For now, you can install from our pre-built binary (Linux only):
 
+```sh
+curl -sSL https://raw.githubusercontent.com/brasilisclub/zignr/install-script/install.sh | bash -
+```
+
+> To make `zignr` available globally you should have `~/.local/bin` on you `PATH`
 
 # Usage
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+binary_url="https://github.com/ivansantiagojr/zignr/releases/download/v0.1.1/binary-0.1.1-x86_64-linux"
+binary_name="zignr"
+
+echo "Downloading zignr..."
+wget -q "$binary_url" -O "$binary_name"
+
+if [ $? -ne 0 ]; then
+    echo "Failed to download zignr."
+    exit 1
+fi
+
+echo "Making zignr executable..."
+chmod +x "$binary_name"
+
+echo "Moving zignr to ~/.local/bin..."
+mv "$binary_name" "$HOME/.local/bin/$binary_name"
+
+# Verify installation
+if [ $? -eq 0 ]; then
+    echo "zignr installed successfully!"
+else
+    echo "Failed to move zignr to ~/.local/bin. You might need sudo privileges."
+    exit 1
+fi
+
+echo
+echo "add ~/.local/bin to you PATH so you can run zignr from anywhere"
+echo "then use run zignr"


### PR DESCRIPTION
This creates a **very** simple installation script for zignr. It works by downloading the pre built binaries on GitHub and moving them to `~/.local/bin` under the name of `zignr`.

Can you help me test it, @thigcampos?

It should work now if you use
```sh
curl -sSL https://raw.githubusercontent.com/brasilisclub/zignr/install-script/install.sh | bash -
```

In a near future I aim to have this proccess like:
```sh
curl -sSL https://zignr.brasilis.club/install.sh | bash -
```
