### PR TITLE
cd: add macos build on cd

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,9 +13,9 @@ jobs:
       fail-fast: false
       matrix:
         TARGET:
-          [
-            x86_64-linux,
-          ]
+          - x86_64-linux
+          - x86_64-macos
+          - aarch64-macos
 
     steps:
       - name: Checkout the repository


### PR DESCRIPTION
Adding the distribution of x86_64 and arm macOS builds.