### PR TITLE
feat: add list command

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,7 +32,7 @@ jobs:
           version: 0.13.0
 
       - name: Build
-        run: zig build --release -Dtarget=${{ matrix.TARGET }}
+        run: zig build -Dtarget=${{ matrix.TARGET }} --release
 
       - name: Renaming the binary
         run: mv zig-out/bin/zignr zig-out/bin/binary-${{ env.RELEASE_VERSION }}-${{ matrix.TARGET }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,7 +32,7 @@ jobs:
           version: 0.13.0
 
       - name: Build
-        run: zig build -Dtarget=${{ matrix.TARGET }}
+        run: zig build --release -Dtarget=${{ matrix.TARGET }}
 
       - name: Renaming the binary
         run: mv zig-out/bin/zignr zig-out/bin/binary-${{ env.RELEASE_VERSION }}-${{ matrix.TARGET }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,10 @@ on:
 
 jobs:
   build:
-    name: "Build with args: '${{ matrix.OPTIMIZE }}'"
+    name: "Building Test"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        OPTIMIZE: [""]
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
@@ -26,7 +24,7 @@ jobs:
           version: 0.13.0
 
       - name: Build
-        run: zig build ${{ matrix.OPTIMIZE }}
+        run: zig build --release
 
       - name: Check formatting
         run: zig fmt --check .

--- a/README.md
+++ b/README.md
@@ -3,18 +3,6 @@
 This is a CLI tool to generate `.gitgnore` files written in zig.
 
 
-zignr is not finished, and is just a project I develop to learn zig. I will link my references below.
-
-First of all, zignr is heavily inspired by [ignr.py](https://github.com/Antrikshy/ignr.py), which uses the [gitignore.io](https://www.toptal.com/developers/gitignore) API.
-
-Zig references I used:
-
-- [Zig Cookbook](https://zigcc.github.io/zig-cookbook/) 
-- [Zig documentation](https://ziglang.org/documentation/master/) 
-- [Zig Common Tasks](https://renatoathaydes.github.io/zig-common-tasks/) 
-- [Ziglings](https://codeberg.org/ziglings)
-- [Zig Guides](https://github.com/tr1ckydev/zig_guides)
-
 
 # Installation
 
@@ -28,9 +16,30 @@ curl -sSL https://raw.githubusercontent.com/brasilisclub/zignr/main/install.sh |
 
 # Usage
 
-To create a .gitgnore file you can simply use `zignr <language> >> .gitnore`. This command will overwrite your .gitignore file. Example:
-```
-zignr zig >> .gitgnore
+To create a .gitgnore file you can simply use `zignr <language> > .gitnore`. This command will overwrite your .gitignore file. Example:
+```bash
+zignr zig > .gitgnore
 ```
 
-To see the list of all .gitignore templates just use `zignr list`, but I did not implemented that yet.
+Multi language example:
+```bash
+zignr zig,python,lua > .gitgnore
+```
+
+To see the list of all .gitignore templates you can call `zignr` with, just use:
+```bash
+zignr list
+```
+
+# References
+This project started as a Zig learning experience (and still is), so I will link my references below:
+First of all, zignr is heavily inspired by [ignr.py](https://github.com/Antrikshy/ignr.py), which uses the [gitignore.io](https://www.toptal.com/developers/gitignore) API.
+
+Zig references I used:
+
+- [Zig Cookbook](https://zigcc.github.io/zig-cookbook/) 
+- [Zig documentation](https://ziglang.org/documentation/master/) 
+- [Zig Common Tasks](https://renatoathaydes.github.io/zig-common-tasks/) 
+- [Ziglings](https://codeberg.org/ziglings)
+- [Zig Guides](https://github.com/tr1ckydev/zig_guides)
+- [Introduction to Zig](https://pedropark99.github.io/zig-book/)

--- a/build.zig
+++ b/build.zig
@@ -10,6 +10,8 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
+        .strip = true,
+        .single_threaded = true,
     });
 
     b.installArtifact(exe);

--- a/build.zig
+++ b/build.zig
@@ -1,54 +1,27 @@
 const std = @import("std");
 
-// Although this function looks imperative, note that its job is to
-// declaratively construct a build graph that will be executed by an external
-// runner.
 pub fn build(b: *std.Build) void {
-    // Standard target options allows the person running `zig build` to choose
-    // what target to build for. Here we do not override the defaults, which
-    // means any target is allowed, and the default is native. Other options
-    // for restricting supported target set are available.
     const target = b.standardTargetOptions(.{});
 
-    // Standard optimization options allow the person running `zig build` to select
-    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall. Here we do not
-    // set a preferred release mode, allowing the user to decide how to optimize.
-    const optimize = b.standardOptimizeOption(.{});
+    const optimize = b.standardOptimizeOption(.{ .preferred_optimize_mode = .ReleaseSafe });
 
     const exe = b.addExecutable(.{
         .name = "zignr",
-        // In this case the main source file is merely a path, however, in more
-        // complicated build scripts, this could be a generated file.
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
     });
 
-    // This declares intent for the executable to be installed into the
-    // standard location when the user invokes the "install" step (the default
-    // step when running `zig build`).
     b.installArtifact(exe);
 
-    // This *creates* a Run step in the build graph, to be executed when another
-    // step is evaluated that depends on it. The next line below will establish
-    // such a dependency.
     const run_cmd = b.addRunArtifact(exe);
 
-    // By making the run step depend on the install step, it will be run from the
-    // installation directory rather than directly from within the cache directory.
-    // This is not necessary, however, if the application depends on other installed
-    // files, this ensures they will be present and in the expected location.
     run_cmd.step.dependOn(b.getInstallStep());
 
-    // This allows the user to pass arguments to the application in the build
-    // command itself, like this: `zig build run -- arg1 arg2 etc`
     if (b.args) |args| {
         run_cmd.addArgs(args);
     }
 
-    // This creates a build step. It will be visible in the `zig build --help` menu,
-    // and can be selected like this: `zig build run`
-    // This will evaluate the `run` step rather than the default, which is "install".
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);
 }

--- a/install.sh
+++ b/install.sh
@@ -1,30 +1,62 @@
 #!/bin/bash
 
-binary_url="https://github.com/ivansantiagojr/zignr/releases/download/v0.1.1/binary-0.1.1-x86_64-linux"
-binary_name="zignr"
+APP_VERSION="v0.1.2"
+BASE_URL="https://github.com/brasilisclub/zignr/releases/download/$APP_VERSION"
 
-echo "Downloading zignr..."
-wget -q "$binary_url" -O "$binary_name"
+BINARY_URL_LINUX="$BASE_URL/BINARY-0.1.2-X86_64-LINUX"
+BINARY_URL_MACOS_ARM="$BASE_URL/BINARY-0.1.2-AARCH64-MACOS"
+BINARY_URL_MACOS="$BASE_URL/binary-0.1.2-x86_64-macos"
+APP_NAME="zignr"
+OS_TYPE=$OSTYPE
+CPU_TYPE=$CPUTYPE
 
-if [ $? -ne 0 ]; then
-    echo "Failed to download zignr."
-    exit 1
-fi
 
-echo "Making zignr executable..."
-chmod +x "$binary_name"
+download_and_create_executable() {
+	echo "Downloading zignr..."
+	wget -q "$binary_url" -O "$APP_NAME"
 
-echo "Moving zignr to ~/.local/bin..."
-mv "$binary_name" "$HOME/.local/bin/$binary_name"
+	if [ $? -ne 0 ]; then
+    	echo "Failed to download zignr."
+    	exit 1
+	fi
 
-# Verify installation
-if [ $? -eq 0 ]; then
-    echo "zignr installed successfully!"
-else
-    echo "Failed to move zignr to ~/.local/bin. You might need sudo privileges."
-    exit 1
-fi
+	echo "Making zignr executable..."
+	chmod +x "$APP_NAME"
+}
 
-echo
-echo "add ~/.local/bin to you PATH so you can run zignr from anywhere"
-echo "then use run zignr"
+linux_install () {
+	echo "Moving zignr to ~/.local/bin..."
+	mv "$APP_NAME" "$HOME/.local/bin/$APP_NAME"
+
+	# Verify installation
+	if [ $? -eq 0 ]; then
+	    echo "zignr installed successfully!"
+	else
+	    echo "Failed to move zignr to ~/.local/bin. You might need sudo privileges."
+	    exit 1
+	fi
+
+	echo
+	echo "Add ~/.local/bin to you PATH so you can run zignr from anywhere"
+	echo "Then use run zignr"
+}
+
+macos_install(){
+	echo "Mac installation will be supported soon"
+}
+
+case "$OSTYPE" in
+	linux-gnu)
+		binary_url=$BINARY_URL_LINUX
+		download_and_create_executable
+		linux_install
+		;;
+	darwin)
+		if [[ $CPU_TYPE == "x86_64" ]]; then
+			binary_url=$BINARY_URL_MACOS
+		fi
+		binary_url=$BINARY_URL_MACOS_ARM
+		download_and_create_executable
+		macos_install
+		;;
+esac

--- a/src/api.zig
+++ b/src/api.zig
@@ -1,0 +1,40 @@
+const std = @import("std");
+const http = std.http;
+
+const base_url = "https://www.toptal.com/developers/gitignore/api/";
+
+const RequestError = error{NotFound};
+
+pub fn request(allocator: std.mem.Allocator, args: [][:0]u8, path: []const u8) ![]u8 {
+    var client = http.Client{ .allocator = allocator };
+    defer client.deinit();
+    var url_buffer: [256]u8 = undefined;
+    const url_to_request = std.fmt.bufPrint(&url_buffer, "{s}{s}", .{ base_url, path }) catch |err| {
+        return err;
+    };
+
+    const uri = try std.Uri.parse(url_to_request);
+    const buf = try allocator.alloc(u8, 1024 * 1014 * 4);
+    defer allocator.free(buf);
+
+    var req = try client.open(.GET, uri, .{ .server_header_buffer = buf });
+    defer req.deinit();
+
+    try req.send();
+    try req.finish();
+    try req.wait();
+
+    if (req.response.status != .ok) {
+        std.debug.print(
+            \\Something went wrong. Check you passed only valid languages/templates.
+            \\Use: '{s}' to see the available languages/templates
+        , .{args[0]});
+        return RequestError.NotFound;
+    }
+
+    var rdr = req.reader();
+    const body = try rdr.readAllAlloc(allocator, 1024 * 1024 * 4);
+    //defer allocator.free(body);
+
+    return body;
+}

--- a/src/commands.zig
+++ b/src/commands.zig
@@ -1,0 +1,27 @@
+const std = @import("std");
+const print = std.io.getStdOut().writer();
+const request = @import("api.zig").request;
+
+// get language .gitgnore command
+pub fn getGitignoreContent(args: [][:0]u8, languages: []const u8) !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+
+    const allocator = gpa.allocator();
+    const body = try request(allocator, args, languages);
+    defer allocator.free(body);
+
+    try print.print("{s}\n", .{body});
+}
+
+// list command
+pub fn listAvailableLanguages(args: [][:0]u8) !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    const body = try request(allocator, args, "list");
+    defer allocator.free(body);
+
+    try print.print("{s}\n", .{body});
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const print = std.io.getStdOut().writer();
 const http = std.http;
+const commands = @import("commands.zig");
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -16,36 +17,10 @@ pub fn main() !void {
     }
 
     if (std.mem.eql(u8, args[1], "list")) {
-        std.debug.print("Not implemented yet\n", .{});
+        try commands.listAvailableLanguages(args);
         return;
     }
+
     const language = std.mem.sliceTo(args[1], 0);
-
-    var client = http.Client{ .allocator = allocator };
-    defer client.deinit();
-    const base_url = "https://www.toptal.com/developers/gitignore/api/";
-    var url_buffer: [256]u8 = undefined;
-    const url_to_request = try std.fmt.bufPrint(&url_buffer, "{s}{s}", .{ base_url, language });
-
-    const uri = try std.Uri.parse(url_to_request);
-    const buf = try allocator.alloc(u8, 1024 * 1014 * 4);
-    defer allocator.free(buf);
-
-    var req = try client.open(.GET, uri, .{ .server_header_buffer = buf });
-    defer req.deinit();
-
-    try req.send();
-    try req.finish();
-    try req.wait();
-
-    if (req.response.status != .ok) {
-        std.debug.print("Probably not a valid language, use: '{s} list' to see the available languages\n", .{args[0]});
-        return;
-    }
-
-    var rdr = req.reader();
-    const body = try rdr.readAllAlloc(allocator, 1024 * 1024 * 4);
-    defer allocator.free(body);
-
-    try print.print("{s}\n", .{body});
+    try commands.getGitignoreContent(args, language);
 }


### PR DESCRIPTION
This PR:
- adds the promised list command to the zignr (via `zignr list`)
- adds basic separation of code in different files
- add a base structure to the installation script to support MacOS.
- use strip and single threaded options on build.zig

I suggest that we finish supporting MacOS on a next PR, and -possibly- Windows as well.