### PR TITLE
chore: use donotcommit instead of gitignore.io

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-APP_VERSION="0.2.1"
+APP_VERSION="0.3.0"
 BASE_URL="https://github.com/ivansantiagojr/zignr/releases/download/v$APP_VERSION"
 
 BINARY_URL_LINUX="$BASE_URL/BINARY-$APP_VERSION-X86_64-LINUX"

--- a/src/api.zig
+++ b/src/api.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const http = std.http;
 
-const base_url = "https://www.toptal.com/developers/gitignore/api/";
+const base_url = "https://donotcommit.com/api/";
 
 const RequestError = error{NotFound};
 
@@ -27,7 +27,7 @@ pub fn request(allocator: std.mem.Allocator, args: [][:0]u8, path: []const u8) !
     if (req.response.status != .ok) {
         std.debug.print(
             \\Something went wrong. Check you passed only valid languages/templates.
-            \\Use: '{s}' to see the available languages/templates
+            \\Use: '{s} list' to see the available languages/templates
         , .{args[0]});
         return RequestError.NotFound;
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -10,8 +10,23 @@ pub fn main() !void {
     const args = try std.process.argsAlloc(allocator);
     defer std.process.argsFree(allocator, args);
 
+    const help_message =
+        \\Get gitignore templates from command line
+        \\
+        \\Commands:
+        \\
+        \\  zignr list          prints all avaible gitignore templates to stdout.
+        \\  zignr <template>    prints the gitignore content to stdout.
+        \\
+        \\Examples:
+        \\
+        \\  zignr python,lua,zig > .gitignore 
+        \\  The above command puts the gitignore content of Python, Lua and Zig templates into .gitignore file.
+        \\
+    ;
+
     if (args.len != 2) {
-        std.debug.print("Usage: {s} <language>\n", .{args[0]});
+        std.debug.print(help_message, .{});
         return;
     }
 


### PR DESCRIPTION
Using https://donotcommit.com as our API to get templates.