### PR TITLE
Rename project to Omit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# zignr
+# Omit
 
 This is a CLI tool to generate `.gitignore` files written in zig.
 
@@ -7,31 +7,31 @@ This is a CLI tool to generate `.gitignore` files written in zig.
 Install on MacOS or GNU/Linux from our pre-built binary by running:
 
 ```sh
-curl -sSL https://raw.githubusercontent.com/ivansantiagojr/zignr/main/install.sh | bash -
+curl -sSL https://raw.githubusercontent.com/ivansantiagojr/omit/main/install.sh | bash -
 ```
 
-> To make `zignr` available globally you should have `~/.local/bin` on you `PATH`
+> To make `omit` available globally you should have `~/.local/bin` on you `PATH`
 
 # Usage
 
-To create a .gitignore file you can simply use `zignr <language> > .gitignore`. This command will overwrite your .gitignore file. Example:
+To create a .gitignore file you can simply use `omit <language> > .gitignore`. This command will overwrite your .gitignore file. Example:
 ```bash
-zignr zig > .gitignore
+omit zig > .gitignore
 ```
 
 Multi language example:
 ```bash
-zignr zig,python,lua > .gitignore
+omit zig,python,lua > .gitignore
 ```
 
-To see the list of all .gitignore templates you can call `zignr` with, just use:
+To see the list of all .gitignore templates you can call `omit` with, just use:
 ```bash
-zignr list
+omit list
 ```
 
 # References
 This project started as a Zig learning experience (and still is), so I will link my references below:
-First of all, zignr is heavily inspired by [ignr.py](https://github.com/Antrikshy/ignr.py), which uses the [gitignore.io](https://www.toptal.com/developers/gitignore) API.
+First of all, omit is heavily inspired by [ignr.py](https://github.com/Antrikshy/ignr.py), which uses the [gitignore.io](https://www.toptal.com/developers/gitignore) API.
 
 Zig references I used:
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a CLI tool to generate `.gitignore` files written in zig.
 Install on MacOS or GNU/Linux from our pre-built binary by running:
 
 ```sh
-curl -sSL https://raw.githubusercontent.com/ivansantiagojr/omit/main/install.sh | bash -
+curl -sSL https://raw.githubusercontent.com/artefatto/omit/main/install.sh | bash -
 ```
 
 > To make `omit` available globally you should have `~/.local/bin` on you `PATH`

--- a/build.zig
+++ b/build.zig
@@ -6,7 +6,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{ .preferred_optimize_mode = .ReleaseSafe });
 
     const exe = b.addExecutable(.{
-        .name = "zignr",
+        .name = "omit",
         .root_module = b.createModule(.{
             .root_source_file = b.path("src/main.zig"),
             .strip = optimize != .Debug,

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
-    .name = .zignr,
+    .name = .omit,
     .version = "0.3.0",
-    .fingerprint = 0x3b833c668ea9d587,
+    .fingerprint = 0xe15905f19339b4b9,
     .minimum_zig_version = "0.15.2",
     .paths = .{
         "build.zig",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .omit,
-    .version = "0.3.0",
+    .version = "0.4.0",
     .fingerprint = 0xe15905f19339b4b9,
     .minimum_zig_version = "0.15.2",
     .paths = .{

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 APP_VERSION="0.3.0"
-BASE_URL="https://github.com/ivansantiagojr/omit/releases/download/v$APP_VERSION"
+BASE_URL="https://github.com/artefatto/omit/releases/download/v$APP_VERSION"
 
 BINARY_URL_LINUX="$BASE_URL/BINARY-$APP_VERSION-X86_64-LINUX"
 BINARY_URL_MACOS_ARM="$BASE_URL/BINARY-$APP_VERSION-AARCH64-MACOS"

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-APP_VERSION="0.3.0"
+APP_VERSION="0.4.0"
 BASE_URL="https://github.com/artefatto/omit/releases/download/v$APP_VERSION"
 
 BINARY_URL_LINUX="$BASE_URL/BINARY-$APP_VERSION-X86_64-LINUX"

--- a/install.sh
+++ b/install.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 
 APP_VERSION="0.3.0"
-BASE_URL="https://github.com/ivansantiagojr/zignr/releases/download/v$APP_VERSION"
+BASE_URL="https://github.com/ivansantiagojr/omit/releases/download/v$APP_VERSION"
 
 BINARY_URL_LINUX="$BASE_URL/BINARY-$APP_VERSION-X86_64-LINUX"
 BINARY_URL_MACOS_ARM="$BASE_URL/BINARY-$APP_VERSION-AARCH64-MACOS"
 BINARY_URL_MACOS="$BASE_URL/binary-$APP_VERSION-x86_64-macos"
-APP_NAME="zignr"
+APP_NAME="omit"
 OS_TYPE=$OSTYPE
 CPU_TYPE=$CPUTYPE
 
 
 download_and_create_executable() {
-	echo "Downloading zignr..."
+	echo "Downloading omit..."
 
 	# Try curl first, fall back to wget
 	if command -v curl &> /dev/null; then
@@ -22,29 +22,29 @@ download_and_create_executable() {
 	fi
 
 	if [ $? -ne 0 ]; then
-    	echo "Failed to download zignr."
+    	echo "Failed to download omit."
     	exit 1
 	fi
 
-	echo "Making zignr executable..."
+	echo "Making omit executable..."
 	chmod +x "$APP_NAME"
 }
 
 linux_install () {
-	echo "Moving zignr to ~/.local/bin..."
+	echo "Moving omit to ~/.local/bin..."
 	mv "$APP_NAME" "$HOME/.local/bin/$APP_NAME"
 
 	# Verify installation
 	if [ $? -eq 0 ]; then
-	    echo "zignr installed successfully!"
+	    echo "omit installed successfully!"
 	else
-	    echo "Failed to move zignr to ~/.local/bin. You might need sudo privileges."
+	    echo "Failed to move omit to ~/.local/bin. You might need sudo privileges."
 	    exit 1
 	fi
 
 	echo
-	echo "Add ~/.local/bin to you PATH so you can run zignr from anywhere"
-	echo "Then use run zignr"
+	echo "Add ~/.local/bin to you PATH so you can run omit from anywhere"
+	echo "Then use run omit"
 }
 
 macos_install() {

--- a/src/main.zig
+++ b/src/main.zig
@@ -15,12 +15,12 @@ pub fn main() !void {
         \\
         \\Commands:
         \\
-        \\  zignr list          prints all avaible gitignore templates to stdout.
-        \\  zignr <template>    prints the gitignore content to stdout.
+        \\  omit list          prints all avaible gitignore templates to stdout.
+        \\  omit <template>    prints the gitignore content to stdout.
         \\
         \\Examples:
         \\
-        \\  zignr python,lua,zig > .gitignore 
+        \\  omit python,lua,zig > .gitignore
         \\  The above command puts the gitignore content of Python, Lua and Zig templates into .gitignore file.
         \\
     ;


### PR DESCRIPTION
As discussed in private conversations, `zignr` is now `omit`.